### PR TITLE
fix UnicodeDecodeError when trying to use download.py on windows system

### DIFF
--- a/download.py
+++ b/download.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':
     if results.overwrite and os.path.exists(output_directory):
         shutil.rmtree(output_directory)
 
-    with open('README.md') as readme:
+    with open('README.md', 'r', encoding='utf8') as readme:
         readme_html = mistune.markdown(readme.read())
         readme_soup = BeautifulSoup.BeautifulSoup(readme_html, "html.parser")
 


### PR DESCRIPTION
Fix UnicodeDecodeError when trying to use download.py on windows system. The error is as follow
> Traceback (most recent call last):
  File "download.py", line 88, in <module>
    readme_html = mistune.markdown(readme.read())
  File "C:\Users\yuanli\AppData\Local\Continuum\anaconda3\lib\encodings\cp1252.py", line 23, in decode
    return codecs.charmap_decode(input,self.errors,decoding_table)[0]
UnicodeDecodeError: 'charmap' codec can't decode byte 0x9d in position 33415: character maps to \<undefined\>