### PR TITLE
Syntax error: missing '

### DIFF
--- a/download.py
+++ b/download.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':
     if results.overwrite and os.path.exists(output_directory):
         shutil.rmtree(output_directory)
 
-    with open('README.md',encoding='utf8) as readme:
+    with open('README.md',encoding='utf8') as readme:
         readme_html = mistune.markdown(readme.read())
         readme_soup = BeautifulSoup.BeautifulSoup(readme_html, "html.parser")
 


### PR DESCRIPTION
 with open('README.md',encoding='utf8') as readme: